### PR TITLE
Fix links on cards

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -7,3 +7,17 @@
   color: var(--g100);
 }
 
+/* extends link on cards */
+.rf-card {
+  position: relative;
+}
+
+.rf-card a::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  cursor: pointer;
+}

--- a/views/partials/card.ejs
+++ b/views/partials/card.ejs
@@ -1,13 +1,13 @@
 <div class="rf-col-12 rf-col-md-<% if (locals.size) { %><%= size %><% } else { %>4<% } %>">
-  <a href="<%= url %>" class="rf-card">
+  <div class="rf-card">
     <% if (img) { %>
     <div class="rf-card__img">
         <img src="<%= img %>" />
     </div>
     <% } %>
     <div class="rf-card__body">
-      <h2 class="rf-card__title"><%= title %></h2>
+      <h2 class="rf-card__title"><a href="<%= url %>"><%= title %></a></h2>
       <p class="rf-card__desc"><%= description %></p>
     </div>
-  </a>
+  </div>
 </div>


### PR DESCRIPTION
Correctif remonté par le SIG, pour être conforme à la doc : 

> La carte possède un seul lien dont l’intitulé est explicite : la balise <a> est placée sur le titre de la carte (balise Hx). La zone de clic pourra être étendue à toute la carte en CSS.